### PR TITLE
feat: Display subscription names and color squares in calendar

### DIFF
--- a/subscription-manager/src/app/calendar/calendar.component.html
+++ b/subscription-manager/src/app/calendar/calendar.component.html
@@ -22,7 +22,12 @@
          [class.selected]="selectedDate && day.dateObj.toDateString() === selectedDate.toDateString()"
          (click)="onDateClick(day)">
       <span>{{ day.dateNumber }}</span>
-      <div *ngIf="day.hasSubscriptions && day.isCurrentMonth" class="subscription-indicator-dot"></div>
+      <div *ngIf="day.subscriptions && day.subscriptions.length > 0 && day.isCurrentMonth" class="subscriptions-list">
+        <div *ngFor="let sub of day.subscriptions" class="subscription-item">
+          <div class="subscription-color-square"></div> <!-- Placeholder for colored square -->
+          <span class="subscription-name">{{ sub.name }}</span>
+        </div>
+      </div>
       <!-- More detailed subscription indicators can be added here if needed -->
       <!-- Example: <div *ngFor="let sub of getSubscriptionsForCell(day.dateObj)" class="subscription-indicator">{{ sub.name }}</div> -->
     </div>

--- a/subscription-manager/src/app/calendar/calendar.component.scss
+++ b/subscription-manager/src/app/calendar/calendar.component.scss
@@ -82,16 +82,38 @@
   color: #e0e0e0; /* Slightly different if selected but other month */
 }
 
+/* Styles for subscription display within calendar cells */
+.subscriptions-list {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start; /* Align items to the start of the cell */
+  gap: 2px; /* Space between subscription items */
+  margin-top: 5px; /* Space below the date number */
+  padding-left: 2px; /* Small padding to not stick to the very edge */
+}
 
-.subscription-indicator-dot {
-  position: absolute;
-  bottom: 8px;
-  right: 8px;
+.subscription-item {
+  display: flex;
+  align-items: center; /* Vertically align square and text */
+  font-size: 0.75em; /* Smaller font for subscription name */
+  line-height: 1.2;
+  color: #333; /* Darker text for better readability */
+  /* Example: if you want to limit width and add ellipsis for long names */
+  /* max-width: 100%; */
+  /* white-space: nowrap; */
+  /* overflow: hidden; */
+  /* text-overflow: ellipsis; */
+}
+
+.subscription-color-square {
   width: 8px;
   height: 8px;
-  background-color: #e74c3c; /* Red dot */
-  border-radius: 50%;
+  background-color: #3498db; /* Default color (e.g., blue) */
+  border-radius: 2px; /* Slightly rounded corners */
+  margin-right: 4px; /* Space between square and name */
+  flex-shrink: 0; /* Prevent square from shrinking if item text is long */
 }
+/* End of subscription display styles */
 
 .details-section {
   margin-top: 25px;

--- a/subscription-manager/src/app/calendar/calendar.component.spec.ts
+++ b/subscription-manager/src/app/calendar/calendar.component.spec.ts
@@ -1,23 +1,155 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { By } from '@angular/platform-browser';
 import { CalendarComponent } from './calendar.component';
+import { Subscription, SubscriptionService } from '../subscription.service'; // Adjusted path
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { SubscriptionFormComponent } from '../subscription-form/subscription-form.component';
+
+// Mock SubscriptionService
+class MockSubscriptionService {
+  subscriptions: Subscription[] = [];
+
+  getSubscriptionsByDate(date: Date): Subscription[] {
+    return this.subscriptions.filter(sub => 
+      sub.paymentDate.getFullYear() === date.getFullYear() &&
+      sub.paymentDate.getMonth() === date.getMonth() &&
+      sub.paymentDate.getDate() === date.getDate()
+    );
+  }
+
+  // Add other methods if needed by the component, e.g., addSubscription, etc.
+  // For this test suite, getSubscriptionsByDate is the primary concern for display.
+}
 
 describe('CalendarComponent', () => {
   let component: CalendarComponent;
   let fixture: ComponentFixture<CalendarComponent>;
+  let mockSubscriptionService: MockSubscriptionService;
 
   beforeEach(async () => {
+    mockSubscriptionService = new MockSubscriptionService();
+
     await TestBed.configureTestingModule({
-      imports: [CalendarComponent]
+      imports: [
+        CommonModule, // Import if your component's template uses common directives like *ngFor, *ngIf
+        FormsModule,  // Import if your component uses FormsModule features like ngModel
+        CalendarComponent, // CalendarComponent is standalone
+        // SubscriptionFormComponent // Already imported by CalendarComponent as it's standalone
+      ],
+      providers: [
+        { provide: SubscriptionService, useValue: mockSubscriptionService }
+      ]
     })
     .compileComponents();
 
     fixture = TestBed.createComponent(CalendarComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    // ngOnInit is called automatically, which calls generateCalendarGrid
+    // If you need to override subscriptions before ngOnInit, setup mockSubscriptionService.subscriptions here
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  describe('Subscription Display in Calendar Grid', () => {
+    beforeEach(() => {
+      // Set currentMonth to a fixed date for predictable testing
+      component.currentMonth = new Date(2024, 6, 1); // July 2024
+      // Clear any subscriptions from previous tests
+      mockSubscriptionService.subscriptions = []; 
+    });
+
+    it('should display subscription name and color square for a day in current month with subscriptions', () => {
+      const testDate = new Date(2024, 6, 15); // July 15, 2024
+      const mockSub: Subscription = { id: '1', name: 'Netflix', price: 15, cycle: 'monthly', paymentDate: testDate };
+      mockSubscriptionService.subscriptions.push(mockSub);
+
+      component.generateCalendarGrid(); // Regenerate grid with new sub data
+      fixture.detectChanges();
+
+      const dayCellElement = fixture.debugElement.queryAll(By.css('.day-cell'))
+        .find(cell => {
+          const dayNumber = cell.query(By.css('span'))?.nativeElement.textContent.trim();
+          return cell.classes['current-month'] && dayNumber === '15';
+        });
+
+      expect(dayCellElement).withContext('Day cell for July 15th not found').toBeTruthy();
+      
+      const subscriptionsList = dayCellElement!.query(By.css('.subscriptions-list'));
+      expect(subscriptionsList).withContext('Subscriptions list not found for July 15th').toBeTruthy();
+      
+      const subscriptionItem = subscriptionsList!.query(By.css('.subscription-item'));
+      expect(subscriptionItem).withContext('Subscription item not found').toBeTruthy();
+      
+      const colorSquare = subscriptionItem!.query(By.css('.subscription-color-square'));
+      expect(colorSquare).withContext('Color square not found').toBeTruthy();
+      
+      const subscriptionName = subscriptionItem!.query(By.css('.subscription-name'));
+      expect(subscriptionName).withContext('Subscription name not found').toBeTruthy();
+      expect(subscriptionName!.nativeElement.textContent).toContain('Netflix');
+    });
+
+    it('should display multiple subscriptions for a day in current month', () => {
+      const testDate = new Date(2024, 6, 18); // July 18, 2024
+      const mockSub1: Subscription = { id: '1', name: 'Spotify', price: 10, cycle: 'monthly', paymentDate: testDate };
+      const mockSub2: Subscription = { id: '2', name: 'HBO Max', price: 15, cycle: 'monthly', paymentDate: testDate };
+      mockSubscriptionService.subscriptions.push(mockSub1, mockSub2);
+
+      component.generateCalendarGrid();
+      fixture.detectChanges();
+
+      const dayCellElement = fixture.debugElement.queryAll(By.css('.day-cell'))
+        .find(cell => cell.classes['current-month'] && cell.query(By.css('span'))?.nativeElement.textContent.trim() === '18');
+      
+      expect(dayCellElement).withContext('Day cell for July 18th not found').toBeTruthy();
+      const subscriptionItems = dayCellElement!.queryAll(By.css('.subscription-item'));
+      expect(subscriptionItems.length).withContext('Incorrect number of subscription items').toBe(2);
+      expect(subscriptionItems[0].query(By.css('.subscription-name'))!.nativeElement.textContent).toContain('Spotify');
+      expect(subscriptionItems[1].query(By.css('.subscription-name'))!.nativeElement.textContent).toContain('HBO Max');
+    });
+
+    it('should NOT display subscription elements for a day in current month without subscriptions', () => {
+      component.currentMonth = new Date(2024, 6, 1); // July 2024
+      // No subscriptions added to mockSubscriptionService
+
+      component.generateCalendarGrid();
+      fixture.detectChanges();
+      
+      // Check day 10 (arbitrary day, ensure it's within the month)
+      const dayCellElement = fixture.debugElement.queryAll(By.css('.day-cell'))
+        .find(cell => cell.classes['current-month'] && cell.query(By.css('span'))?.nativeElement.textContent.trim() === '10');
+
+      expect(dayCellElement).withContext('Day cell for July 10th not found').toBeTruthy();
+      const subscriptionsList = dayCellElement!.query(By.css('.subscriptions-list'));
+      expect(subscriptionsList).withContext('Subscriptions list should NOT be present for July 10th').toBeFalsy();
+    });
+
+    it('should NOT display subscription elements for a padding day (other month) even if it has subscriptions', () => {
+      // July 2024 starts on a Monday. So, June 30th (Sunday) will be a padding day.
+      component.currentMonth = new Date(2024, 6, 1); // July 2024
+      const prevMonthDate = new Date(2024, 5, 30); // June 30, 2024
+      const mockSub: Subscription = { id: '3', name: 'PaddingSub', price: 5, cycle: 'monthly', paymentDate: prevMonthDate };
+      mockSubscriptionService.subscriptions.push(mockSub);
+
+      component.generateCalendarGrid();
+      fixture.detectChanges();
+      
+      // Find the cell for June 30th (it will be an "other-month" cell)
+      const paddingDayCellElement = fixture.debugElement.queryAll(By.css('.day-cell'))
+      .find(cell => {
+        const dayNumber = cell.query(By.css('span'))?.nativeElement.textContent.trim();
+        // Check if it's an "other-month" cell and the date number matches
+        return cell.classes['other-month'] && dayNumber === '30';
+      });
+      
+      expect(paddingDayCellElement).withContext('Padding day cell for June 30th not found').toBeTruthy();
+      // Ensure it is indeed an "other-month" cell
+      expect(paddingDayCellElement!.classes['other-month']).toBeTrue();
+
+      const subscriptionsList = paddingDayCellElement!.query(By.css('.subscriptions-list'));
+      expect(subscriptionsList).withContext('Subscriptions list should NOT be present for padding day June 30th').toBeFalsy();
+    });
   });
 });

--- a/subscription-manager/src/app/calendar/calendar.component.ts
+++ b/subscription-manager/src/app/calendar/calendar.component.ts
@@ -8,7 +8,7 @@ interface CalendarDay {
   dateObj: Date;
   dateNumber: number;
   isCurrentMonth: boolean;
-  hasSubscriptions: boolean;
+  subscriptions: Subscription[];
 }
 
 @Component({
@@ -51,7 +51,7 @@ export class CalendarComponent implements OnInit {
         dateObj: prevMonthDay,
         dateNumber: prevMonthDay.getDate(),
         isCurrentMonth: false,
-        hasSubscriptions: this.subscriptionService.getSubscriptionsByDate(prevMonthDay).length > 0
+        subscriptions: this.subscriptionService.getSubscriptionsByDate(prevMonthDay)
       });
     }
     
@@ -62,7 +62,7 @@ export class CalendarComponent implements OnInit {
         dateObj: dayDate,
         dateNumber: i,
         isCurrentMonth: true,
-        hasSubscriptions: this.subscriptionService.getSubscriptionsByDate(dayDate).length > 0
+        subscriptions: this.subscriptionService.getSubscriptionsByDate(dayDate)
       });
     }
 
@@ -76,7 +76,7 @@ export class CalendarComponent implements OnInit {
             dateObj: nextMonthDay,
             dateNumber: nextMonthDay.getDate(),
             isCurrentMonth: false,
-            hasSubscriptions: this.subscriptionService.getSubscriptionsByDate(nextMonthDay).length > 0
+            subscriptions: this.subscriptionService.getSubscriptionsByDate(nextMonthDay)
             });
         }
     }
@@ -88,7 +88,7 @@ export class CalendarComponent implements OnInit {
             dateObj: nextDay,
             dateNumber: nextDay.getDate(),
             isCurrentMonth: false, // Assuming these are padding days from next month
-            hasSubscriptions: this.subscriptionService.getSubscriptionsByDate(nextDay).length > 0
+            subscriptions: this.subscriptionService.getSubscriptionsByDate(nextDay)
          });
      }
 


### PR DESCRIPTION
Replaces the dot indicator in the calendar with a more detailed view. Each day cell with subscriptions now lists the subscription names, each preceded by a colored square.

Changes:
- Updated `CalendarDay` interface to store subscription objects.
- Modified `generateCalendarGrid` to populate this new property.
- Updated HTML template to render names and color squares.
- Added SCSS styles for the new elements.
- Added comprehensive unit tests to verify the new display logic.